### PR TITLE
test

### DIFF
--- a/tools/GenerateChangelog/ss13_autochangelog.py
+++ b/tools/GenerateChangelog/ss13_autochangelog.py
@@ -62,7 +62,7 @@ new = 0
 # Parse PR body for changelog entries
 print('Reading changelogs...')
 for line in args.pr_body.splitlines():
-	print(f"Checking line '{line}'")
+	print(f"Checking lin '{line}'")
 	if line[:1] == "??": # Find the start of the changelog
 		print("Found opening :cl: tag")
 		if incltag == True: # If we're already reading logs, skip


### PR DESCRIPTION
(Tested with the exact same text as the first PR, which failed because python is a fuck
Requested by basically everyone who knows that this is a thing elsewhere, merry christmas I guess.
🆑
experimental - Adds new github action to automatically update the changelog from merged PR descriptions
/🆑

And it does seem to match correctly, despite notepad++ suddenly deciding that it no longer liked displaying the cl tag character